### PR TITLE
Streaming support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod stream;
+
 use brotli;
 use wasm_bindgen::prelude::*;
 use serde::{Serialize, Deserialize};
@@ -6,7 +8,7 @@ use serde::{Serialize, Deserialize};
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-fn set_panic_hook() {
+pub fn set_panic_hook() {
     #[cfg(feature="console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,97 @@
+use crate::set_panic_hook;
+use brotli::enc::StandardAlloc; // Re-exported from alloc_stdlib::StandardAlloc
+use brotli::{BrotliDecompressStream, BrotliResult, BrotliState};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[repr(i32)]
+pub enum BrotliStreamResult {
+    /// The stream is just initialized and no input is provided currently.
+    /// `BrotliResult` uses `ResultFailure = 0`, but as we will convert `ResultFailure` to a negative actual error code,
+    /// 0 is reused as no input currently.
+    Init = 0,
+    ResultSuccess = 1,
+    NeedsMoreInput = 2,
+    NeedsMoreOutput = 3,
+}
+
+#[wasm_bindgen]
+pub struct CompressStream {}
+
+#[wasm_bindgen]
+impl CompressStream {}
+
+#[wasm_bindgen]
+pub struct DecompressStream {
+    state: BrotliState<StandardAlloc, StandardAlloc, StandardAlloc>,
+    result: i32,
+    total_out: usize,
+}
+
+#[wasm_bindgen]
+impl DecompressStream {
+    #[allow(clippy::new_without_default)]
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        set_panic_hook();
+        let alloc = StandardAlloc::default();
+        Self {
+            state: BrotliState::new(alloc, alloc, alloc),
+            result: BrotliStreamResult::Init as i32,
+            total_out: 0,
+        }
+    }
+
+    pub fn decompress(
+        &mut self,
+        input: Box<[u8]>,
+        output_size: usize,
+    ) -> Result<Box<[u8]>, JsValue> {
+        let mut output = vec![0; output_size];
+        let mut available_in = input.len();
+        let mut input_offset = 0;
+        let mut available_out = output_size;
+        let mut output_offset = 0;
+        match BrotliDecompressStream(
+            &mut available_in,
+            &mut input_offset,
+            &input,
+            &mut available_out,
+            &mut output_offset,
+            &mut output,
+            &mut self.total_out,
+            &mut self.state,
+        ) {
+            BrotliResult::ResultFailure => {
+                // It should be a negative error code
+                self.result = self.state.error_code as i32;
+                Err(JsValue::from_str(&format!(
+                    "Brotli streaming decompress failed: Error code {}",
+                    self.result
+                )))
+            }
+            BrotliResult::NeedsMoreOutput => {
+                self.result = BrotliStreamResult::NeedsMoreOutput as i32;
+                Ok(output.into_boxed_slice())
+            }
+            BrotliResult::ResultSuccess => {
+                output.truncate(output_offset);
+                self.result = BrotliStreamResult::ResultSuccess as i32;
+                Ok(output.into_boxed_slice())
+            }
+            BrotliResult::NeedsMoreInput => {
+                output.truncate(output_offset);
+                self.result = BrotliStreamResult::NeedsMoreInput as i32;
+                Ok(output.into_boxed_slice())
+            }
+        }
+    }
+
+    pub fn total_out(&self) -> usize {
+        self.total_out
+    }
+
+    pub fn result(&self) -> i32 {
+        self.result
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,11 @@
-use crate::set_panic_hook;
+use crate::{set_panic_hook, Options};
+use brotli::enc::encode::{
+    BrotliEncoderCompressStream, BrotliEncoderCreateInstance, BrotliEncoderDestroyInstance,
+    BrotliEncoderIsFinished, BrotliEncoderOperation, BrotliEncoderParameter,
+    BrotliEncoderSetParameter, BrotliEncoderStateStruct,
+};
 use brotli::enc::StandardAlloc; // Re-exported from alloc_stdlib::StandardAlloc
-use brotli::{BrotliDecompressStream, BrotliResult, BrotliState};
+use brotli::{self, BrotliDecompressStream, BrotliResult, BrotliState};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -9,6 +14,7 @@ pub enum BrotliStreamResult {
     /// The stream is just initialized and no input is provided currently.
     /// `BrotliResult` uses `ResultFailure = 0`, but as we will convert `ResultFailure` to a negative actual error code,
     /// 0 is reused as no input currently.
+    /// As for Brotli compressing, since offical API does not provide a way to retrieve a detailed error code, -1 is used.
     Init = 0,
     ResultSuccess = 1,
     NeedsMoreInput = 2,
@@ -16,10 +22,133 @@ pub enum BrotliStreamResult {
 }
 
 #[wasm_bindgen]
-pub struct CompressStream {}
+pub struct CompressStream {
+    state: BrotliEncoderStateStruct<StandardAlloc>,
+    result: i32,
+    total_out: usize,
+}
+
+impl Drop for CompressStream {
+    fn drop(&mut self) {
+        BrotliEncoderDestroyInstance(&mut self.state);
+    }
+}
 
 #[wasm_bindgen]
-impl CompressStream {}
+impl CompressStream {
+    #[wasm_bindgen(constructor)]
+    pub fn new(raw_options: &JsValue) -> Result<CompressStream, JsValue> {
+        set_panic_hook();
+        let options: Options = if raw_options.is_undefined() {
+            serde_json::from_str("{}").unwrap()
+        } else if raw_options.is_object() {
+            raw_options.into_serde().unwrap()
+        } else {
+            return Err(JsValue::from_str("Options is not an object"));
+        };
+        let alloc = StandardAlloc::default();
+        let mut state = BrotliEncoderCreateInstance(alloc);
+        BrotliEncoderSetParameter(
+            &mut state,
+            BrotliEncoderParameter::BROTLI_PARAM_QUALITY,
+            options.quality as u32,
+        );
+        Ok(Self {
+            state,
+            result: BrotliStreamResult::Init as i32,
+            total_out: 0,
+        })
+    }
+
+    pub fn compress(
+        &mut self,
+        input_opt: Option<Box<[u8]>>,
+        output_size: usize,
+    ) -> Result<Box<[u8]>, JsValue> {
+        let mut nop_callback = |_data: &mut brotli::interface::PredictionModeContextMap<
+            brotli::interface::InputReferenceMut,
+        >,
+                                _cmds: &mut [brotli::interface::StaticCommand],
+                                _mb: brotli::interface::InputPair,
+                                _mfv: &mut StandardAlloc| ();
+        let mut output = vec![0; output_size];
+        let mut input_offset = 0;
+        let mut available_out = output_size;
+        let mut output_offset = 0;
+        match input_opt {
+            Some(input) => {
+                let op = BrotliEncoderOperation::BROTLI_OPERATION_PROCESS;
+                let mut available_in = input.len();
+                let ret = BrotliEncoderCompressStream(
+                    &mut self.state,
+                    op,
+                    &mut available_in,
+                    &input,
+                    &mut input_offset,
+                    &mut available_out,
+                    &mut output,
+                    &mut output_offset,
+                    &mut Some(self.total_out),
+                    &mut nop_callback,
+                );
+                if ret != 0 {
+                    if available_out == 0 {
+                        self.result = BrotliStreamResult::NeedsMoreOutput as i32;
+                        Ok(output.into_boxed_slice())
+                    } else if available_in == 0 {
+                        output.truncate(output_offset);
+                        self.result = BrotliStreamResult::NeedsMoreInput as i32;
+                        Ok(output.into_boxed_slice())
+                    } else {
+                        self.result = -1;
+                        Err(JsValue::from_str("Unexpected Brotli streaming compress: both available_in & available_out are not 0 after a successful processing"))
+                    }
+                } else {
+                    self.result = -1;
+                    Err(JsValue::from_str(
+                        "Brotli streaming compress failed: When processing",
+                    ))
+                }
+            }
+            None => {
+                let op = BrotliEncoderOperation::BROTLI_OPERATION_FINISH;
+                let input = Vec::new().into_boxed_slice();
+                let mut available_in = 0;
+                while BrotliEncoderIsFinished(&mut self.state) == 0 {
+                    let ret = BrotliEncoderCompressStream(
+                        &mut self.state,
+                        op,
+                        &mut available_in,
+                        &input,
+                        &mut input_offset,
+                        &mut available_out,
+                        &mut output,
+                        &mut output_offset,
+                        &mut Some(self.total_out),
+                        &mut nop_callback,
+                    );
+                    if ret == 0 {
+                        self.result = -1;
+                        return Err(JsValue::from_str(
+                            "Brotli streaming compress failed: When finishing",
+                        ));
+                    }
+                }
+                output.truncate(output_offset);
+                self.result = BrotliStreamResult::ResultSuccess as i32;
+                Ok(output.into_boxed_slice())
+            }
+        }
+    }
+
+    pub fn total_out(&self) -> usize {
+        self.total_out
+    }
+
+    pub fn result(&self) -> i32 {
+        self.result
+    }
+}
 
 #[wasm_bindgen]
 pub struct DecompressStream {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -81,6 +81,9 @@ impl CompressStream {
             Some(input) => {
                 let op = BrotliEncoderOperation::BROTLI_OPERATION_PROCESS;
                 let mut available_in = input.len();
+                // `BrotliEncoderCompressStream` does not return a `BrotliResult` but returns a boolean,
+                // which is different from `BrotliDecompressStream`.
+                // But the requirement for input/output buf is common so we reused `BrotliStreamResult` to report it.
                 let ret = BrotliEncoderCompressStream(
                     &mut self.state,
                     op,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -95,14 +95,14 @@ impl CompressStream {
                     &mut nop_callback,
                 );
                 if ret != 0 {
-                    if available_out == 0 {
-                        self.result = BrotliStreamResult::NeedsMoreOutput as i32;
-                        self.last_input_offset = input_offset;
-                        Ok(output.into_boxed_slice())
-                    } else if available_in == 0 {
+                    if available_in == 0 {
                         output.truncate(output_offset);
                         self.result = BrotliStreamResult::NeedsMoreInput as i32;
                         self.last_input_offset = input.len();
+                        Ok(output.into_boxed_slice())
+                    } else if available_out == 0 {
+                        self.result = BrotliStreamResult::NeedsMoreOutput as i32;
+                        self.last_input_offset = input_offset;
                         Ok(output.into_boxed_slice())
                     } else {
                         self.result = -1;

--- a/test/brotli.spec.ts
+++ b/test/brotli.spec.ts
@@ -206,6 +206,19 @@ describe("Brotli-wasm", () => {
         expect(Buffer.from(brotli.decompress(output)).toString('base64')).to.equal(input.toString('base64'));
     });
 
+    it("streaming compressing can handle needing more output when action is finish", () => {
+        const input = Buffer.from('Some thrilling text I urgently need to compress');
+        const stream = new brotli.CompressStream();
+        const output1 = stream.compress(input, 1);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output2 = stream.compress(undefined, 1);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreOutput);
+        const output3 = stream.compress(undefined, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        const output = Buffer.concat([output1, output2, output3]);
+        expect(Buffer.from(brotli.decompress(output)).toString('base64')).to.equal(input.toString('base64'));
+    });
+
     it("streaming decompressing can handle needing more output", () => {
         const input = Buffer.from('GxoAABypU587dC0k9ianQOgqjS32iUTcCA==', 'base64');
         const stream = new brotli.DecompressStream();

--- a/test/brotli.spec.ts
+++ b/test/brotli.spec.ts
@@ -191,7 +191,8 @@ describe("Brotli-wasm", () => {
         expect(decOutput.toString('utf8')).to.equal(s);
     });
 
-    it("streaming compressing can handle needing more output when action is process", () => {
+    it("streaming compressing can handle needing more output when action is process", function () {
+        this.timeout(10000);
         // The input should be more than about 1.6MB with enough randomness
         // to make the compressor ask for more output space when the action is PROCESS
         const input = genRandBytes(1600000);

--- a/test/brotli.spec.ts
+++ b/test/brotli.spec.ts
@@ -69,6 +69,37 @@ describe("Brotli-wasm", () => {
         expect(result).to.equal(input);
     });
 
+    it("can streamingly compress data", () => {
+        const input = Buffer.from("Test input data");
+        const input1 = input.slice(0, input.length / 2);
+        const input2 = input.slice(input.length / 2);
+        const stream = new brotli.CompressStream();
+        const output1 = stream.compress(input1, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output2 = stream.compress(input2, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output3 = stream.compress(undefined, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        expect(Buffer.concat([output1, output2, output3]).toString('base64')).to.equal('Gw4A+KWpyubolCCjVAjmxJ4D');
+    });
+
+    it("can streamingly compress data with a different quality setting", () => {
+        const input = Buffer.from("Test input data");
+        const input1 = input.slice(0, input.length / 2);
+        const input2 = input.slice(input.length / 2);
+        const quality = 1;
+        const stream = new brotli.CompressStream(quality);
+        const output1 = stream.compress(input1, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output2 = stream.compress(input2, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output3 = stream.compress(undefined, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        // It will be CwOAVGVzdCBpbjgACHB1dCBkYXRhAw== which is different.
+        // But it can still be decompressed back to the original string.
+        // expect(Buffer.concat([output1, output2, output3]).toString('base64')).to.equal('CweAVGVzdCBpbnB1dCBkYXRhAw==');
+    });
+
     it("can streamingly decompress data", () => {
         // Generated with: echo -n '$CONTENT' | brotli --stdout - | base64
         const input = Buffer.from('GxoAABypU587dC0k9ianQOgqjS32iUTcCA==', 'base64');
@@ -82,6 +113,21 @@ describe("Brotli-wasm", () => {
         expect(Buffer.concat([output1, output2]).toString('utf8')).to.equal('Brotli brotli brotli brotli');
     });
 
+    it("does not fail when streamingly compressing with an illegal quality value", () => {
+        const input = Buffer.from("Test input data");
+        const input1 = input.slice(0, input.length / 2);
+        const input2 = input.slice(input.length / 2);
+        const quality = 12;
+        const stream = new brotli.CompressStream(quality);
+        const output1 = stream.compress(input1, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output2 = stream.compress(input2, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const output3 = stream.compress(undefined, 100);
+        expect(stream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        expect(Buffer.concat([output1, output2, output3]).toString('base64')).to.equal('Gw4A+KWpyubolCCjVAjmxJ4D');
+    });
+
     it("cleanly fails when streamingly decompressing garbage", () => {
         const input = Buffer.from("This is not brotli data, it's just a string");
         const stream = new brotli.DecompressStream();
@@ -89,5 +135,58 @@ describe("Brotli-wasm", () => {
             stream.decompress(input, 100)
         ).to.throw('Brotli streaming decompress failed');
         expect(stream.result()).to.lt(0);
+    });
+
+    it("can compress & decompress back to the original result", () => {
+        const s = "Some thrilling text I urgently need to compress";
+        const encInput = Buffer.from(s);
+        const encInput1 = encInput.slice(0, encInput.length / 2);
+        const encInput2 = encInput.slice(encInput.length / 2);
+        const encStream = new brotli.CompressStream();
+        const encOutput1 = encStream.compress(encInput1, 100);
+        expect(encStream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const encOutput2 = encStream.compress(encInput2, 100);
+        expect(encStream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const encOutput3 = encStream.compress(undefined, 100);
+        expect(encStream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        const encOutput = Buffer.concat([encOutput1, encOutput2, encOutput3]);
+
+        const decInput1 = encOutput.slice(0, encOutput.length / 2);
+        const decInput2 = encOutput.slice(encOutput.length / 2);
+        const decStream = new brotli.DecompressStream();
+        const decOutput1 = decStream.decompress(decInput1, 100);
+        expect(decStream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const decOutput2 = decStream.decompress(decInput2, 100);
+        expect(decStream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        const decOutput = Buffer.concat([decOutput1, decOutput2]);
+
+        expect(decOutput.toString('utf8')).to.equal(s);
+    });
+
+    it("can compress & decompress back to the original result with a different quality setting", () => {
+        const s = "Some thrilling text I urgently need to compress";
+        const encInput = Buffer.from(s);
+        const encInput1 = encInput.slice(0, encInput.length / 2);
+        const encInput2 = encInput.slice(encInput.length / 2);
+        const quality = 3;
+        const encStream = new brotli.CompressStream(quality);
+        const encOutput1 = encStream.compress(encInput1, 100);
+        expect(encStream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const encOutput2 = encStream.compress(encInput2, 100);
+        expect(encStream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const encOutput3 = encStream.compress(undefined, 100);
+        expect(encStream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        const encOutput = Buffer.concat([encOutput1, encOutput2, encOutput3]);
+
+        const decInput1 = encOutput.slice(0, encOutput.length / 2);
+        const decInput2 = encOutput.slice(encOutput.length / 2);
+        const decStream = new brotli.DecompressStream();
+        const decOutput1 = decStream.decompress(decInput1, 100);
+        expect(decStream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
+        const decOutput2 = decStream.decompress(decInput2, 100);
+        expect(decStream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
+        const decOutput = Buffer.concat([decOutput1, decOutput2]);
+
+        expect(decOutput.toString('utf8')).to.equal(s);
     });
 });

--- a/test/brotli.spec.ts
+++ b/test/brotli.spec.ts
@@ -95,9 +95,10 @@ describe("Brotli-wasm", () => {
         expect(stream.result()).to.equal(brotli.BrotliStreamResult.NeedsMoreInput);
         const output3 = stream.compress(undefined, 100);
         expect(stream.result()).to.equal(brotli.BrotliStreamResult.ResultSuccess);
-        // It will be CwOAVGVzdCBpbjgACHB1dCBkYXRhAw== which is different.
+        // It will be different from non-streaming result.
         // But it can still be decompressed back to the original string.
-        // expect(Buffer.concat([output1, output2, output3]).toString('base64')).to.equal('CweAVGVzdCBpbnB1dCBkYXRhAw==');
+        let output = Buffer.concat([output1, output2, output3]);
+        expect(Buffer.from(brotli.decompress(output)).toString('base64')).to.equal(input.toString('base64'));
     });
 
     it("can streamingly decompress data", () => {
@@ -137,7 +138,7 @@ describe("Brotli-wasm", () => {
         expect(stream.result()).to.lt(0);
     });
 
-    it("can compress & decompress back to the original result", () => {
+    it("can streamingly compress & decompress back to the original result", () => {
         const s = "Some thrilling text I urgently need to compress";
         const encInput = Buffer.from(s);
         const encInput1 = encInput.slice(0, encInput.length / 2);
@@ -163,7 +164,7 @@ describe("Brotli-wasm", () => {
         expect(decOutput.toString('utf8')).to.equal(s);
     });
 
-    it("can compress & decompress back to the original result with a different quality setting", () => {
+    it("can streamingly compress & decompress back to the original result with a different quality setting", () => {
         const s = "Some thrilling text I urgently need to compress";
         const encInput = Buffer.from(s);
         const encInput1 = encInput.slice(0, encInput.length / 2);


### PR DESCRIPTION
Close #10

The PR adds 2 structs `CompressStream` & `DecompressStream` to allow users to pass data for (de)compressing piece by piece, which helps to decrease memory usage when transfering data. Tests are included and all OK.

Some notable points:

- Other than using stream (reader/writer) API of `brotli` crate (It is hard to export these Rust streaming stuff from WASM to JS), the PR uses low-level API [`BrotliEncoderCompressStream`](https://brotli.org/encode.html#a512) & [`BrotliDecoderDecompressStream`](https://brotli.org/decode.html#a234) (renamed as `BrotliDecompressStream`) to impl the feature
- Other than reusing `Options`, `CompressStream` gets `quality` directly from args because I do not find a way (like `skip_typescript`) to disable all types of a class. That means I can not put a hand-written defination like function `compress` into `typescript_custom_section`.
- Consumed input buf size, `last_input_offset`, is returned separatedly from `last_input_offset` method, because returning it together with `Box<[u8]>` in one struct/tuple/others is hard (for Box<[u8]>, may require importing JS Object to Rust AFAIK). Results of every piece are also returned via another method because of the same reason.
- One test shows that streaming or not may affect the compressing result. Since it can be decompressed back to the original string, IMO it is expected.
- Bundle size does not change

Left tasks:

- [x] Streaming (de)compressing impl
- [x] Basic tests from `brotli.spec.ts` for streaming (de)compressing API
- [x] Specified tests for streaming (de)compressing API (like differring needing more input/output)
- [x] Bundle size evaluation
- [ ] Documentation or even quick start (maybe later)