### PR TITLE
Docs: add in stream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ await inputStream
 console.log(output) // Prints 'some input'
 ```
 
+Note that `TransformStream` has become available in all browsers as of mid-2022. https://caniuse.com/mdn-api_transformstream
+
 ## Alternatives
 
 There's a few other packages that do similar things, but I found they were all unusable and/or unmaintained:


### PR DESCRIPTION
- Added in WebStream example
- Switched browser example to use TextDecode to match WebStream example, and prefer no polyfill first.

Note: I asked about #14 for a new library I'm working on (https://github.com/willfarrell/datastream/tree/main/packages/compress)

Closes: #14